### PR TITLE
Add scrollsToTop support to InfiniteScrollView

### DIFF
--- a/Sources/InfiniteScrollView/InfiniteScrollView.swift
+++ b/Sources/InfiniteScrollView/InfiniteScrollView.swift
@@ -26,6 +26,7 @@ public struct InfiniteScrollView<Content: View, ChangeIndex: Equatable>: View {
     public let decreaseIndexAction: (ChangeIndex) -> ChangeIndex?
     public var onCenteredIndexChanged: ((ChangeIndex) -> Void)?
     public var stopScrollingOnUpdate: Bool
+    public var scrollsToTop: Bool
 
     public init(
         spacing: CGFloat = 0,
@@ -38,6 +39,7 @@ public struct InfiniteScrollView<Content: View, ChangeIndex: Equatable>: View {
         decreaseIndexAction: @escaping (ChangeIndex) -> ChangeIndex?,
         onCenteredIndexChanged: ((ChangeIndex) -> Void)? = nil,
         stopScrollingOnUpdate: Bool = true,
+        scrollsToTop: Bool = false,
         @ViewBuilder content: @escaping (ChangeIndex) -> Content
     ) {
         self.spacing = spacing
@@ -51,6 +53,7 @@ public struct InfiniteScrollView<Content: View, ChangeIndex: Equatable>: View {
         self.decreaseIndexAction = decreaseIndexAction
         self.onCenteredIndexChanged = onCenteredIndexChanged
         self.stopScrollingOnUpdate = stopScrollingOnUpdate
+        self.scrollsToTop = scrollsToTop
     }
 
     public var body: some View {
@@ -65,6 +68,7 @@ public struct InfiniteScrollView<Content: View, ChangeIndex: Equatable>: View {
             decreaseIndexAction: decreaseIndexAction,
             onCenteredIndexChanged: onCenteredIndexChanged,
             stopScrollingOnUpdate: stopScrollingOnUpdate,
+            scrollsToTop: scrollsToTop,
             content: content
         )
     }

--- a/Sources/InfiniteScrollView/InfiniteScrollViewContainer.swift
+++ b/Sources/InfiniteScrollView/InfiniteScrollViewContainer.swift
@@ -20,6 +20,7 @@ public struct InfiniteScrollViewContainer<ChangeIndex: Equatable, Content: View>
     public let decreaseIndexAction: (ChangeIndex) -> ChangeIndex?
     public let onCenteredIndexChanged: ((ChangeIndex) -> Void)?
     public let stopScrollingOnUpdate: Bool
+    public let scrollsToTop: Bool
     public let content: (ChangeIndex) -> Content
     
     @State private var coordinateSpaceID = UUID()
@@ -44,6 +45,7 @@ public struct InfiniteScrollViewContainer<ChangeIndex: Equatable, Content: View>
         decreaseIndexAction: @escaping (ChangeIndex) -> ChangeIndex?,
         onCenteredIndexChanged: ((ChangeIndex) -> Void)?,
         stopScrollingOnUpdate: Bool,
+        scrollsToTop: Bool = false,
         content: @escaping (ChangeIndex) -> Content
     ) {
         self.spacing = spacing
@@ -56,6 +58,7 @@ public struct InfiniteScrollViewContainer<ChangeIndex: Equatable, Content: View>
         self.decreaseIndexAction = decreaseIndexAction
         self.onCenteredIndexChanged = onCenteredIndexChanged
         self.stopScrollingOnUpdate = stopScrollingOnUpdate
+        self.scrollsToTop = scrollsToTop
         self.content = content
         
         let windowSize = Self.windowSize(for: self.contentMultiplier)
@@ -127,6 +130,7 @@ extension InfiniteScrollViewContainer {
     func scrollBody(viewportSize: CGSize) -> some View {
         ScrollView(orientation.axis, showsIndicators: false) {
             stackContent
+                .scrollsToTopCompat(scrollsToTop)
         }
         .defaultScrollAnchorCompat(.center)
         .scrollDisabledCompat(isScrollDisabled)

--- a/Sources/InfiniteScrollView/View+InfiniteScrollCompat.swift
+++ b/Sources/InfiniteScrollView/View+InfiniteScrollCompat.swift
@@ -33,4 +33,89 @@ extension View {
             self
         }
     }
+
+    @ViewBuilder
+    func scrollsToTopCompat(_ enabled: Bool) -> some View {
+#if os(iOS)
+        background(
+            ScrollViewConfigurator { scrollView in
+                scrollView.scrollsToTop = enabled
+            }
+        )
+#else
+        self
+#endif
+    }
 }
+
+#if os(iOS)
+import UIKit
+
+private struct ScrollViewConfigurator: UIViewRepresentable {
+    let configure: (UIScrollView) -> Void
+
+    func makeUIView(context: Context) -> ScrollViewResolverView {
+        let view = ScrollViewResolverView()
+        view.isUserInteractionEnabled = false
+        return view
+    }
+
+    func updateUIView(_ uiView: ScrollViewResolverView, context: Context) {
+        uiView.configure = configure
+        uiView.resolve()
+    }
+}
+
+private final class ScrollViewResolverView: UIView {
+    var configure: ((UIScrollView) -> Void)?
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        resolve()
+    }
+
+    override func didMoveToSuperview() {
+        super.didMoveToSuperview()
+        resolve()
+    }
+
+    func resolve() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let scrollView = self.resolveScrollView() else { return }
+            self.configure?(scrollView)
+        }
+    }
+
+    private func resolveScrollView() -> UIScrollView? {
+        if let scrollView = enclosingScrollView { return scrollView }
+        guard let superview else { return nil }
+        return findScrollView(in: superview)
+    }
+}
+
+private extension UIView {
+    var enclosingScrollView: UIScrollView? {
+        var view: UIView? = self
+        while let current = view {
+            if let scrollView = current as? UIScrollView {
+                return scrollView
+            }
+            view = current.superview
+        }
+        return nil
+    }
+}
+
+@MainActor
+private func findScrollView(in view: UIView) -> UIScrollView? {
+    for subview in view.subviews {
+        if let scrollView = subview as? UIScrollView {
+            return scrollView
+        }
+        if let scrollView = findScrollView(in: subview) {
+            return scrollView
+        }
+    }
+    return nil
+}
+#endif


### PR DESCRIPTION
Introduces a scrollsToTop property to InfiniteScrollView and InfiniteScrollViewContainer, allowing control over the UIScrollView.scrollsToTop behavior on iOS. Implements a View extension and supporting UIKit code to configure this property, enabling or disabling tap-to-scroll-to-top functionality.