### PR TITLE
Improve initial centering logic in InfiniteScrollView

### DIFF
--- a/Sources/InfiniteScrollView/InfiniteScrollViewContainer.swift
+++ b/Sources/InfiniteScrollView/InfiniteScrollViewContainer.swift
@@ -32,7 +32,8 @@ public struct InfiniteScrollViewContainer<ChangeIndex: Equatable, Content: View>
     @State var isScrollDisabled = false
     @State var suppressChangeIndexReaction = false
     @State var pendingProgrammaticTarget: ChangeIndex?
-    @State var didCenterInitially = false
+    @State var pendingInitialCentering = true
+    @State var initialCenteringAttempts = 0
     
     public init(
         spacing: CGFloat,


### PR DESCRIPTION
Refactors the initial centering mechanism by introducing a retry system and new state variables to better handle edge cases where the initial centering may fail. Updates state management from 'didCenterInitially' to 'pendingInitialCentering' and adds logic to stabilize scroll position when necessary.

Closes: #3 